### PR TITLE
Update std::ceil and std::floor to std::bit_ceil and std::bit_floor

### DIFF
--- a/16_and_17/Projects/05-OtherBit/src/main.cpp
+++ b/16_and_17/Projects/05-OtherBit/src/main.cpp
@@ -19,14 +19,14 @@ void testCeilFloor() {
     for (uint32_t value = 0; value < 8u; ++value) {
         std::cout << std::format("ceil({}): {}",
             std::bitset<4>(value).to_string(),
-            std::bitset<4>(std::ceil(value)).to_string()
+            std::bitset<4>(std::bit_ceil(value)).to_string()
         ) << std::endl;
     }
 
     for (uint32_t value = 0; value < 8u; ++value) {
         std::cout << std::format("ceil({}): {}",
             std::bitset<4>(value).to_string(),
-            std::bitset<4>(std::floor(value)).to_string()
+            std::bitset<4>(std::bit_floor(value)).to_string()
         ) << std::endl;
     }
 }


### PR DESCRIPTION
I found it occurs to difference about ceil and floor between code and comment. I think it should be std::bit_ceil and std::bit_floor.